### PR TITLE
Added script for standardizing formatting using eslint-prettier; #21

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "format": "prettier --write \"**/*.{js,jsx,css}\""
+    "format": "prettier --write \"**/*.{ts,tsx,js,md,mdx,css,yaml}\"",
+    "check": "prettier --check \"**/*.{ts,tsx,js,md,mdx,css,yaml}\""
   },
   "dependencies": {
     "@clerk/clerk-react": "^5.21.0",


### PR DESCRIPTION
Can be run using 
```
npm run format
```

Used to standardize code format prior to committing

Partially resolves #21 but is NOT github actions workflow