### PR TITLE
#61- Hotfix for the images being served on the route path

### DIFF
--- a/src/components/ReviewList/ReviewList.jsx
+++ b/src/components/ReviewList/ReviewList.jsx
@@ -107,8 +107,8 @@ const ReviewList =  (props) => {
                                         value <=
                                         (ratings[`${category}-hover`] ||
                                             ratings[category])
-                                            ? '../../public/img/star-yellow.png'
-                                            : '../../public/img/star-white-transp.png'
+                                            ? '/img/star-yellow.png'
+                                            : '/img/star-white-transp.png'
                                     }
                                     alt="star"
                                     className="star"


### PR DESCRIPTION
@Tayun-Codes 

#61 - Adjusted the image path for the star images in the review form so that the error (Files in the public directory are served at the root path.) is resolved