### PR TITLE
Added custom font to fix the font not displaying properly

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -12,7 +12,7 @@ export default function Header() {
         <header className="header">
             <nav className="navbar">
                 <div className="logo">
-                    <a href="/">Kinfolx</a>
+                    <a href="/" className="font-ahsing">Kinfolx</a>
                 </div>
                 <SearchBar className="header_search" />
                 <ul className="nav-links">

--- a/src/components/Header/header.css
+++ b/src/components/Header/header.css
@@ -19,7 +19,7 @@
     margin-right: 1rem;
     font-size: 1.8rem;
     font-weight: bold;
-    font-family: 'Ahsing';
+    /* font-family: 'Ahsing'; */
 }
 
 .logo a {

--- a/src/index.css
+++ b/src/index.css
@@ -19,6 +19,7 @@
     --font-poppins: "Poppins", "sans-serif";
     --font-source-code: "Source Code Pro", "monospace";
     --font-roboto: "Roboto Condensed", "sans-serif";
+    --font-ahsing: 'Ahsing', "sans-serif";
 }
 
 html,
@@ -173,7 +174,10 @@ body,
 
 @font-face {
     font-family: 'Ahsing';
-    src: 'public/ahsing-regular.otf';
+    src: url('../public/ahsing-regular.otf') format("otf");
+    font-style: normal;
+    font-weight: 700;
+    font-display: swap;
 }
 
 /* Scrollbar */


### PR DESCRIPTION
Issue #129 
- The custom font we were using for the logo didn't work on devices that didn't have font installed on it. 
- I changed the src property in the font-face rule to use url and the relative path to the font
- I gave the font a default style and font-weight and font-display for performance 
- I also added the custom font to the tailwind theme