### PR TITLE
Changed the path of the custom font and format so font now shows properly

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -174,7 +174,7 @@ body,
 
 @font-face {
     font-family: 'Ahsing';
-    src: url('../public/ahsing-regular.otf') format("otf");
+    src: url('/ahsing-regular.otf') format("opentype");
     font-style: normal;
     font-weight: 700;
     font-display: swap;


### PR DESCRIPTION
- The path of the font needed to be changed as well as the font format. So the font now works for devices that don't have the the font installed. 